### PR TITLE
feat: transactions screen

### DIFF
--- a/src/__tests__/transactions-route.spec.tsx
+++ b/src/__tests__/transactions-route.spec.tsx
@@ -87,4 +87,60 @@ describe('TransactionsRoute', () => {
     expect(filtersSpy).toHaveBeenCalledTimes(2);
     expect(txSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('amount sort toggles chevron direction', async () => {
+    vi.spyOn(client, 'filters').mockResolvedValue(mockFilters);
+    vi.spyOn(client, 'transactions').mockResolvedValue(makePage());
+    render(
+      <MemoryRouter initialEntries={['/transactions']}>
+        <DashboardProvider config={dashboardConfig}>
+          <TransactionsRoute />
+        </DashboardProvider>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+    const amountHeader = screen.getByRole('button', { name: 'Amount' });
+    expect(amountHeader).toHaveAttribute('aria-sort', 'none'); // initial state might be date_desc
+    fireEvent.click(amountHeader);
+    await waitFor(() => expect(amountHeader).toHaveAttribute('aria-sort', 'descending'));
+    fireEvent.click(amountHeader);
+    await waitFor(() => expect(amountHeader).toHaveAttribute('aria-sort', 'ascending'));
+  });
+
+  it('filter pill removal updates live region', async () => {
+    vi.spyOn(client, 'filters').mockResolvedValue(mockFilters);
+    vi.spyOn(client, 'transactions').mockResolvedValue(makePage());
+    render(
+      <MemoryRouter initialEntries={['/transactions?category=Food&period=7d']}>
+        <DashboardProvider config={dashboardConfig}>
+          <TransactionsRoute />
+        </DashboardProvider>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+    const liveRegion = screen.getByText(/Filters active:/i);
+    expect(liveRegion).toBeInTheDocument();
+    const removeCategory = screen.getByRole('button', { name: /Remove category filter/i });
+    fireEvent.click(removeCategory);
+    await waitFor(() => expect(liveRegion.textContent).not.toMatch(/Category Food/));
+  });
+
+  it('pagination aria-live updates range on next page', async () => {
+    vi.spyOn(client, 'filters').mockResolvedValue(mockFilters);
+    vi.spyOn(client, 'transactions').mockResolvedValue(makePage(60,0,20));
+    render(
+      <MemoryRouter initialEntries={['/transactions']}>
+        <DashboardProvider config={dashboardConfig}>
+          <TransactionsRoute />
+        </DashboardProvider>
+      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+  screen.getByText(/1–20 of 60/);
+    const nextBtn = screen.getByRole('button', { name: /Next/i });
+    // mock second page after click
+    (client.transactions as unknown as () => Promise<unknown>) = () => Promise.resolve(makePage(60,20,20));
+    fireEvent.click(nextBtn);
+    await waitFor(() => expect(screen.getByText(/21–40 of 60/)).toBeInTheDocument());
+  });
 });

--- a/src/__tests__/transactions-route.spec.tsx
+++ b/src/__tests__/transactions-route.spec.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DashboardProvider } from '../layouts/dashboard/DashboardProvider';
+import dashboardConfig from '../app/config/dashboard.config';
+import { TransactionsRoute } from '../app/routes/TransactionsRoute';
+import * as client from '../data/client';
+import type { FiltersResponse, TransactionsPage } from '../data/models';
+
+const mockFilters: FiltersResponse = {
+  categories: [
+    { name: 'Food', color: '#ff9900', icon: 'Utensils' },
+    { name: 'Travel', color: '#3366ff', icon: 'Plane' },
+  ],
+  dateRangePresets: [
+    { label: '7 Days', value: '7d' },
+    { label: '30 Days', value: '30d' },
+  ]
+};
+
+function makePage(total = 40, offset = 0, limit = 20): TransactionsPage {
+  return {
+    transactions: Array.from({ length: Math.min(limit, total - offset) }).map((_, i) => ({
+      id: 't' + (offset + i),
+      date: new Date(2025, 8, 1 + i).toISOString(),
+      merchant: 'Shop ' + i,
+      category: i % 2 ? 'Travel' : 'Food',
+      amount: i % 3 ? 123.45 : -50.5,
+      description: 'Desc',
+      paymentMethod: 'Card',
+      icon: 'Circle',
+      categoryColor: '#000'
+    })),
+    pagination: { total, limit, offset, hasMore: offset + limit < total }
+  };
+}
+
+describe('TransactionsRoute', () => {
+  it('syncs category chip to URL and back', async () => {
+    vi.spyOn(client, 'filters').mockResolvedValue(mockFilters);
+    vi.spyOn(client, 'transactions').mockResolvedValue(makePage());
+    render(
+      <MemoryRouter initialEntries={['/transactions']}>\n        <DashboardProvider config={dashboardConfig}>\n          <TransactionsRoute />\n        </DashboardProvider>\n      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByRole('table', { name: /Transactions table/i })).toBeInTheDocument());
+    const foodChip = screen.getByRole('button', { name: 'Food' });
+    fireEvent.click(foodChip);
+    await waitFor(() => expect(foodChip).toHaveAttribute('aria-pressed', 'true'));
+  });
+
+  it('toggles date sort aria-sort states', async () => {
+    vi.spyOn(client, 'filters').mockResolvedValue(mockFilters);
+    vi.spyOn(client, 'transactions').mockResolvedValue(makePage());
+    render(
+      <MemoryRouter initialEntries={['/transactions']}>\n        <DashboardProvider config={dashboardConfig}>\n          <TransactionsRoute />\n        </DashboardProvider>\n      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+    const dateHeader = screen.getByRole('button', { name: 'Date' });
+    expect(dateHeader).toHaveAttribute('aria-sort', 'descending');
+    fireEvent.click(dateHeader);
+    await waitFor(() => expect(dateHeader).toHaveAttribute('aria-sort', 'ascending'));
+  });
+
+  it('paging disables next at end', async () => {
+    vi.spyOn(client, 'filters').mockResolvedValue(mockFilters);
+    vi.spyOn(client, 'transactions').mockResolvedValue(makePage(40, 0, 20));
+    render(
+      <MemoryRouter initialEntries={['/transactions']}>\n        <DashboardProvider config={dashboardConfig}>\n          <TransactionsRoute />\n        </DashboardProvider>\n      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+    const nextBtn = screen.getByRole('button', { name: /Next/i });
+    fireEvent.click(nextBtn);
+    // mock second page
+    (client.transactions as unknown as () => Promise<unknown>) = () => Promise.resolve(makePage(40, 20, 20));
+    await waitFor(() => expect(nextBtn).toBeEnabled());
+  });
+
+  it('error then retry restores list', async () => {
+    const filtersSpy = vi.spyOn(client, 'filters').mockRejectedValueOnce(new Error('fail filters')).mockResolvedValue(mockFilters);
+    const txSpy = vi.spyOn(client, 'transactions').mockRejectedValueOnce(new Error('fail tx')).mockResolvedValue(makePage());
+    render(
+      <MemoryRouter initialEntries={['/transactions']}>\n        <DashboardProvider config={dashboardConfig}>\n          <TransactionsRoute />\n        </DashboardProvider>\n      </MemoryRouter>
+    );
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /Retry/i }));
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+    expect(filtersSpy).toHaveBeenCalledTimes(2);
+    expect(txSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -259,15 +259,20 @@ function TransactionsTable({ rows, sortBy, onChangeSort }: TransactionsTableProp
         </tr>
       </thead>
       <tbody>
-        {rows.map(r => (
-          <tr key={r.id}>
-            <td>{new Date(r.date).toLocaleDateString('en-ZA')}</td>
-            <td>{r.merchant}</td>
-            <td>{r.category}</td>
-            <td className={r.amount < 0 ? 'neg' : ''}>{formatAmount(r.amount)}</td>
-            <td>{r.paymentMethod}</td>
-          </tr>
-        ))}
+        {rows.map(r => {
+          const d = new Date(r.date);
+          const dateLabel = d.toLocaleString('en-ZA', { day:'2-digit', month:'short', year:'numeric', hour:'2-digit', minute:'2-digit' });
+          const iso = r.date;
+          return (
+            <tr key={r.id}>
+              <td title={iso}>{dateLabel}</td>
+              <td className="merchant"><span className="merchant-name">{r.merchant}</span></td>
+              <td className="category"><span className="cat-dot" style={{ background:r.categoryColor }} />{r.category}</td>
+              <td className={r.amount < 0 ? 'neg' : ''}>{formatAmount(r.amount)}</td>
+              <td className="method"><span className="method-icon" aria-hidden="true">💳</span>{r.paymentMethod}</td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -184,7 +184,13 @@ export function TransactionsRoute() {
             <ul className="sk-rows">{Array.from({length:5}).map((_,i)=><li key={i} className="sk-row" />)}</ul>
           </div>
         ) }
-        { !txLoading && !txError && txData && (
+        { !txLoading && !txError && txData && txData.transactions.length === 0 && (
+          <div className="tx-empty" role="status">
+            <p>No transactions found for the selected filters.</p>
+            <button type="button" onClick={resetFilters}>Reset Filters</button>
+          </div>
+        ) }
+        { !txLoading && !txError && txData && txData.transactions.length > 0 && (
           <>
             <TransactionsTable
               rows={txData.transactions}

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -117,7 +117,7 @@ export function TransactionsRoute() {
   const resetFilters = () => update({ category: undefined, period: undefined, offset: 0 });
 
   return (
-    <main className="transactions-route" aria-labelledby="transactions-heading">
+  <main className="transactions-route" aria-labelledby="transactions-heading" role="main">
       <h2 id="transactions-heading">Transactions</h2>
       {/* Filters UI */}
       {isMobile ? (
@@ -149,7 +149,7 @@ export function TransactionsRoute() {
           </details>
         </section>
       ) : (
-        <aside aria-label="Filters" className="tx-filters-desktop">
+  <aside aria-label="Filters" className="tx-filters-desktop" role="complementary">
           <div className="tx-filter-group" aria-labelledby="tx-period-label-d">
             <h3 id="tx-period-label-d">Date Range</h3>
             <div className="chip-column">
@@ -171,7 +171,7 @@ export function TransactionsRoute() {
           </div>
         </aside>
       )}
-      <section aria-label="Results" className="transactions-results-reflection">
+  <section aria-label="Results" className="transactions-results-reflection" role="region" aria-labelledby="transactions-heading">
         { (fltError || txError) && (
           <div role="alert" className="tx-error">
             <p>{fltError || txError}</p>

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -287,9 +287,9 @@ function Pagination({ total, limit, offset, hasMore, onPageChange }: PaginationP
   const nextOffset = offset + limit;
   return (
     <div className="tx-pager" aria-label="Pagination controls">
-      <button type="button" disabled={offset === 0} onClick={() => onPageChange(prevOffset)}>Previous</button>
-      <span className="tx-page-info">{from}–{to} of {total}</span>
-      <button type="button" disabled={!hasMore} onClick={() => onPageChange(nextOffset)}>Next</button>
+      <button type="button" className="pager-btn" disabled={offset === 0} onClick={() => onPageChange(prevOffset)} aria-label="Previous page">‹ Prev</button>
+      <span className="tx-page-info" aria-live="polite">{from}–{to} of {total}</span>
+      <button type="button" className="pager-btn" disabled={!hasMore} onClick={() => onPageChange(nextOffset)} aria-label="Next page">Next ›</button>
     </div>
   );
 }

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import type { TransactionSort, PeriodPreset } from '../../data/models';
+
+interface TxnQueryState {
+  category?: string;
+  period?: PeriodPreset;
+  limit: number;
+  offset: number;
+  sortBy: TransactionSort;
+}
+
+const PERIOD_VALUES: PeriodPreset[] = ['7d','30d','90d','1y'];
+const SORT_VALUES: TransactionSort[] = ['date_desc','date_asc','amount_desc','amount_asc'];
+
+function parseSearch(search: string): TxnQueryState {
+  const usp = new URLSearchParams(search);
+  const category = usp.get('category') || undefined;
+  const periodRaw = usp.get('period') as PeriodPreset | null;
+  const period = periodRaw && PERIOD_VALUES.includes(periodRaw) ? periodRaw : undefined;
+  const limitNum = Number(usp.get('limit'));
+  const offsetNum = Number(usp.get('offset'));
+  const sortRaw = usp.get('sortBy') as TransactionSort | null;
+  const sortBy = sortRaw && SORT_VALUES.includes(sortRaw) ? sortRaw : 'date_desc';
+  return {
+    category,
+    period,
+    limit: Number.isFinite(limitNum) && limitNum > 0 ? limitNum : 20,
+    offset: Number.isFinite(offsetNum) && offsetNum >= 0 ? offsetNum : 0,
+    sortBy,
+  };
+}
+
+function buildSearch(state: TxnQueryState): string {
+  const usp = new URLSearchParams();
+  if (state.category) usp.set('category', state.category);
+  if (state.period) usp.set('period', state.period);
+  if (state.limit !== 20) usp.set('limit', String(state.limit));
+  if (state.offset !== 0) usp.set('offset', String(state.offset));
+  if (state.sortBy !== 'date_desc') usp.set('sortBy', state.sortBy);
+  const s = usp.toString();
+  return s ? `?${s}` : '';
+}
+
+export function TransactionsRoute() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const qs = useMemo(() => parseSearch(location.search), [location.search]);
+
+  // Sync helper: pushes updated params to URL without full reload
+  const update = useCallback((partial: Partial<TxnQueryState>) => {
+    const next: TxnQueryState = { ...qs, ...partial };
+    navigate({ pathname: location.pathname, search: buildSearch(next) }, { replace: false });
+  }, [qs, navigate, location.pathname]);
+
+  // Placeholder UI reflecting current state
+  return (
+    <main className="transactions-route" aria-labelledby="transactions-heading">
+      <h2 id="transactions-heading">Transactions</h2>
+      <section aria-label="Current filters" className="transactions-filters-reflection">
+        <dl>
+          <dt>Category</dt><dd>{qs.category || '—'}</dd>
+          <dt>Period</dt><dd>{qs.period || '—'}</dd>
+          <dt>Limit</dt><dd>{qs.limit}</dd>
+          <dt>Offset</dt><dd>{qs.offset}</dd>
+          <dt>Sort</dt><dd>{qs.sortBy}</dd>
+        </dl>
+        <div className="transactions-temp-controls" aria-label="Temporary controls for URL state">
+          <button type="button" onClick={() => update({ sortBy: qs.sortBy === 'date_desc' ? 'date_asc' : 'date_desc' })}>Toggle Date Sort</button>
+          <button type="button" onClick={() => update({ offset: 0 })}>Reset Offset</button>
+        </div>
+      </section>
+      <section aria-label="Results" className="transactions-results-reflection">
+        <p>Data fetch to be implemented next. (category={qs.category || 'none'}, period={qs.period || 'none'}, limit={qs.limit}, offset={qs.offset}, sort={qs.sortBy})</p>
+      </section>
+    </main>
+  );
+}
+
+export default TransactionsRoute;

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import type { TransactionSort, PeriodPreset, FiltersResponse, TransactionsPage } from '../../data/models';
+import type { TransactionSort, PeriodPreset, FiltersResponse, TransactionsPage, Transaction } from '../../data/models';
 import { filters, transactions } from '../../data/client';
 
 interface TxnQueryState {
@@ -185,7 +185,11 @@ export function TransactionsRoute() {
           </div>
         ) }
         { !txLoading && !txError && txData && (
-          <p>Loaded {txData.transactions.length} rows (table to follow).</p>
+          <TransactionsTable
+            rows={txData.transactions}
+            sortBy={qs.sortBy}
+            onChangeSort={(next) => update({ sortBy: next, offset: 0 })}
+          />
         ) }
       </section>
     </main>
@@ -193,3 +197,52 @@ export function TransactionsRoute() {
 }
 
 export default TransactionsRoute;
+
+interface TransactionsTableProps {
+  rows: Transaction[];
+  sortBy: TransactionSort;
+  onChangeSort: (s: TransactionSort) => void;
+}
+
+function TransactionsTable({ rows, sortBy, onChangeSort }: TransactionsTableProps) {
+  const dateSortState = sortBy.startsWith('date_') ? (sortBy === 'date_desc' ? 'descending' : 'ascending') : 'none';
+  const amountSortState = sortBy.startsWith('amount_') ? (sortBy === 'amount_desc' ? 'descending' : 'ascending') : 'none';
+  function toggleDate() {
+    onChangeSort(sortBy === 'date_desc' ? 'date_asc' : 'date_desc');
+  }
+  function toggleAmount() {
+    onChangeSort(sortBy === 'amount_desc' ? 'amount_asc' : 'amount_desc');
+  }
+  return (
+    <table className="tx-table" aria-label="Transactions table">
+      <thead>
+        <tr>
+          <th>
+            <button type="button" aria-sort={dateSortState} onClick={toggleDate} className="sortable">Date</button>
+          </th>
+          <th>Merchant</th>
+          <th>Category</th>
+          <th>
+            <button type="button" aria-sort={amountSortState} onClick={toggleAmount} className="sortable">Amount</button>
+          </th>
+          <th>Payment Method</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(r => (
+          <tr key={r.id}>
+            <td>{new Date(r.date).toLocaleDateString('en-ZA')}</td>
+            <td>{r.merchant}</td>
+            <td>{r.category}</td>
+            <td className={r.amount < 0 ? 'neg' : ''}>{formatAmount(r.amount)}</td>
+            <td>{r.paymentMethod}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function formatAmount(v: number) {
+  return 'R' + v.toLocaleString('en-ZA', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -185,6 +185,7 @@ export function TransactionsRoute() {
         )}
         { (fltError || txError) && (
           <div role="alert" className="tx-error">
+            <span className="alert-icon" aria-hidden="true">⚠️</span>
             <p>{fltError || txError}</p>
             <button onClick={loadData}>Retry</button>
           </div>
@@ -197,6 +198,8 @@ export function TransactionsRoute() {
         ) }
         { !txLoading && !txError && txData && txData.transactions.length === 0 && (
           <div className="tx-empty" role="status">
+            <div className="tx-illustration" aria-hidden="true">💸</div>
+            <h3>No transactions match</h3>
             <p>No transactions found for the selected filters.</p>
             <button type="button" onClick={resetFilters}>Reset Filters</button>
           </div>

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -119,6 +119,10 @@ export function TransactionsRoute() {
   return (
   <main className="transactions-route" aria-labelledby="transactions-heading" role="main">
       <h2 id="transactions-heading">Transactions</h2>
+      {/* Live region announcing filter changes */}
+      <div aria-live="polite" aria-atomic="true" className="visually-hidden">
+        {qs.category || qs.period ? `Filters active: ${qs.category?`Category ${qs.category}`:''} ${qs.period?`Period ${qs.period}`:''}` : 'No filters active'}
+      </div>
       {/* Filters UI */}
       {isMobile ? (
         <section aria-label="Filters" className="tx-filters-mobile">

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -107,22 +107,70 @@ export function TransactionsRoute() {
   }, [qs, navigate, location.pathname]);
 
   // Placeholder UI reflecting current state
+  const isMobile = typeof window !== 'undefined' ? window.matchMedia('(max-width: 640px)').matches : false;
+
+  const periods = PERIOD_VALUES;
+  const cats = fltData?.categories || [];
+
+  const applyCategory = (c?: string) => update({ category: c, offset: 0 });
+  const applyPeriod = (p?: PeriodPreset) => update({ period: p, offset: 0 });
+  const resetFilters = () => update({ category: undefined, period: undefined, offset: 0 });
+
   return (
     <main className="transactions-route" aria-labelledby="transactions-heading">
       <h2 id="transactions-heading">Transactions</h2>
-      <section aria-label="Current filters" className="transactions-filters-reflection">
-        <dl>
-          <dt>Category</dt><dd>{qs.category || '—'}</dd>
-          <dt>Period</dt><dd>{qs.period || '—'}</dd>
-          <dt>Limit</dt><dd>{qs.limit}</dd>
-          <dt>Offset</dt><dd>{qs.offset}</dd>
-          <dt>Sort</dt><dd>{qs.sortBy}</dd>
-        </dl>
-        <div className="transactions-temp-controls" aria-label="Temporary controls for URL state">
-          <button type="button" onClick={() => update({ sortBy: qs.sortBy === 'date_desc' ? 'date_asc' : 'date_desc' })}>Toggle Date Sort</button>
-          <button type="button" onClick={() => update({ offset: 0 })}>Reset Offset</button>
-        </div>
-      </section>
+      {/* Filters UI */}
+      {isMobile ? (
+        <section aria-label="Filters" className="tx-filters-mobile">
+          <details>
+            <summary>Filters</summary>
+            <div className="tx-filter-group" aria-labelledby="tx-period-label">
+              <h3 id="tx-period-label">Date Range</h3>
+              <div className="chip-row">
+                {periods.map(p => (
+                  <button key={p} type="button" className={`chip ${qs.period===p?'selected':''}`} aria-pressed={qs.period===p}
+                    onClick={() => applyPeriod(qs.period===p?undefined:p)}>{p}</button>
+                ))}
+              </div>
+            </div>
+            <div className="tx-filter-group" aria-labelledby="tx-cat-label">
+              <h3 id="tx-cat-label">Categories</h3>
+              <div className="chip-row">
+                {cats.map(c => (
+                  <button key={c.name} type="button" className={`chip ${qs.category===c.name?'selected':''}`} aria-pressed={qs.category===c.name}
+                    onClick={() => applyCategory(qs.category===c.name?undefined:c.name)}>{c.name}</button>
+                ))}
+              </div>
+            </div>
+            <div className="tx-filter-actions">
+              <button type="button" onClick={() => { /* apply already live via toggle */ }}>Apply</button>
+              <button type="button" onClick={resetFilters}>Reset</button>
+            </div>
+          </details>
+        </section>
+      ) : (
+        <aside aria-label="Filters" className="tx-filters-desktop">
+          <div className="tx-filter-group" aria-labelledby="tx-period-label-d">
+            <h3 id="tx-period-label-d">Date Range</h3>
+            <div className="chip-column">
+              {periods.map(p => (
+                <button key={p} type="button" className={`chip ${qs.period===p?'selected':''}`} aria-pressed={qs.period===p}
+                  onClick={() => applyPeriod(qs.period===p?undefined:p)}>{p}</button>
+              ))}
+            </div>
+          </div>
+          <div className="tx-filter-group" aria-labelledby="tx-cat-label-d">
+            <h3 id="tx-cat-label-d">Categories</h3>
+            <div className="chip-column">
+              {cats.map(c => (
+                <button key={c.name} type="button" className={`chip ${qs.category===c.name?'selected':''}`} aria-pressed={qs.category===c.name}
+                  onClick={() => applyCategory(qs.category===c.name?undefined:c.name)}>{c.name}</button>
+              ))}
+            </div>
+            <button type="button" className="reset-btn" onClick={resetFilters}>Reset</button>
+          </div>
+        </aside>
+      )}
       <section aria-label="Results" className="transactions-results-reflection">
         { (fltError || txError) && (
           <div role="alert" className="tx-error">
@@ -137,7 +185,7 @@ export function TransactionsRoute() {
           </div>
         ) }
         { !txLoading && !txError && txData && (
-          <p>Loaded {txData.transactions.length} rows (show table in later step).</p>
+          <p>Loaded {txData.transactions.length} rows (table to follow).</p>
         ) }
       </section>
     </main>

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -172,6 +172,17 @@ export function TransactionsRoute() {
         </aside>
       )}
   <section aria-label="Results" className="transactions-results-reflection" role="region" aria-labelledby="transactions-heading">
+        {(qs.category || qs.period) && (
+          <div className="tx-active-pills" aria-label="Active filters">
+            {qs.category && (
+              <span className="pill" data-type="category">Category: {qs.category} <button aria-label="Remove category filter" onClick={() => update({ category: undefined, offset:0 })}>×</button></span>
+            )}
+            {qs.period && (
+              <span className="pill" data-type="period">Period: {qs.period} <button aria-label="Remove period filter" onClick={() => update({ period: undefined, offset:0 })}>×</button></span>
+            )}
+            <button type="button" className="clear-all" onClick={() => update({ category: undefined, period: undefined, offset:0 })}>Clear all</button>
+          </div>
+        )}
         { (fltError || txError) && (
           <div role="alert" className="tx-error">
             <p>{fltError || txError}</p>

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -233,12 +233,16 @@ function TransactionsTable({ rows, sortBy, onChangeSort }: TransactionsTableProp
       <thead>
         <tr>
           <th>
-            <button type="button" aria-sort={dateSortState} onClick={toggleDate} className="sortable">Date</button>
+            <button type="button" aria-sort={dateSortState} onClick={toggleDate} className="sortable" title="Sort by Date" aria-label="Sort by Date">
+              Date <span className={`chevron ${dateSortState}`}>▾</span>
+            </button>
           </th>
           <th>Merchant</th>
           <th>Category</th>
           <th>
-            <button type="button" aria-sort={amountSortState} onClick={toggleAmount} className="sortable">Amount</button>
+            <button type="button" aria-sort={amountSortState} onClick={toggleAmount} className="sortable" title="Sort by Amount" aria-label="Sort by Amount">
+              Amount <span className={`chevron ${amountSortState}`}>▾</span>
+            </button>
           </th>
           <th>Payment Method</th>
         </tr>

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import type { TransactionSort, PeriodPreset } from '../../data/models';
+import type { TransactionSort, PeriodPreset, FiltersResponse, TransactionsPage } from '../../data/models';
+import { filters, transactions } from '../../data/client';
 
 interface TxnQueryState {
   category?: string;
@@ -46,6 +47,58 @@ export function TransactionsRoute() {
   const location = useLocation();
   const navigate = useNavigate();
   const qs = useMemo(() => parseSearch(location.search), [location.search]);
+  const customerId = 'user123';
+
+  // Data states
+  const [fltLoading, setFltLoading] = useState(true);
+  const [fltError, setFltError] = useState<string|null>(null);
+  const [fltData, setFltData] = useState<FiltersResponse|null>(null);
+
+  const [txLoading, setTxLoading] = useState(true);
+  const [txError, setTxError] = useState<string|null>(null);
+  const [txData, setTxData] = useState<TransactionsPage|null>(null);
+
+  const abortRef = useRef<AbortController|null>(null);
+
+  function computeDateRange(period?: PeriodPreset): { startDate?: string; endDate?: string } {
+    if (!period) return {};
+    const now = new Date();
+    const endDate = now.toISOString().slice(0,10);
+  const start = new Date(now);
+    const map: Record<PeriodPreset, number> = { '7d':7, '30d':30, '90d':90, '1y':365 };
+    const days = map[period];
+    start.setDate(start.getDate() - (days - 1));
+    const startDate = start.toISOString().slice(0,10);
+    return { startDate, endDate };
+  }
+
+  const loadData = useCallback(async () => {
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+    setFltLoading(true); setFltError(null);
+    setTxLoading(true); setTxError(null);
+    const { startDate, endDate } = computeDateRange(qs.period);
+    const txParams = { limit: qs.limit, offset: qs.offset, category: qs.category, startDate, endDate, sortBy: qs.sortBy };
+    try {
+      const [fRes, tRes] = await Promise.all([
+        filters(customerId, ac.signal),
+        transactions(customerId, txParams, ac.signal)
+      ]);
+      if (ac.signal.aborted) return;
+      setFltData(fRes); setFltLoading(false);
+      setTxData(tRes); setTxLoading(false);
+    } catch (e) {
+      if (ac.signal.aborted) return;
+      const msg = e instanceof Error ? e.message : 'Failed loading transactions';
+      // If filters fail treat separately
+      setFltLoading(false); if (!fltData) setFltError(msg);
+      setTxLoading(false); if (!txData) setTxError(msg);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [customerId, qs.category, qs.limit, qs.offset, qs.period, qs.sortBy]);
+
+  useEffect(() => { loadData(); return () => abortRef.current?.abort(); }, [loadData]);
 
   // Sync helper: pushes updated params to URL without full reload
   const update = useCallback((partial: Partial<TxnQueryState>) => {
@@ -71,7 +124,21 @@ export function TransactionsRoute() {
         </div>
       </section>
       <section aria-label="Results" className="transactions-results-reflection">
-        <p>Data fetch to be implemented next. (category={qs.category || 'none'}, period={qs.period || 'none'}, limit={qs.limit}, offset={qs.offset}, sort={qs.sortBy})</p>
+        { (fltError || txError) && (
+          <div role="alert" className="tx-error">
+            <p>{fltError || txError}</p>
+            <button onClick={loadData}>Retry</button>
+          </div>
+        ) }
+        { (fltLoading || txLoading) && (
+          <div className="tx-skeleton" aria-label="Loading transactions">
+            <div className="sk-header" />
+            <ul className="sk-rows">{Array.from({length:5}).map((_,i)=><li key={i} className="sk-row" />)}</ul>
+          </div>
+        ) }
+        { !txLoading && !txError && txData && (
+          <p>Loaded {txData.transactions.length} rows (show table in later step).</p>
+        ) }
       </section>
     </main>
   );

--- a/src/app/routes/TransactionsRoute.tsx
+++ b/src/app/routes/TransactionsRoute.tsx
@@ -185,11 +185,20 @@ export function TransactionsRoute() {
           </div>
         ) }
         { !txLoading && !txError && txData && (
-          <TransactionsTable
-            rows={txData.transactions}
-            sortBy={qs.sortBy}
-            onChangeSort={(next) => update({ sortBy: next, offset: 0 })}
-          />
+          <>
+            <TransactionsTable
+              rows={txData.transactions}
+              sortBy={qs.sortBy}
+              onChangeSort={(next) => update({ sortBy: next, offset: 0 })}
+            />
+            <Pagination
+              total={txData.pagination.total}
+              limit={txData.pagination.limit}
+              offset={txData.pagination.offset}
+              hasMore={txData.pagination.hasMore}
+              onPageChange={(nextOffset: number) => update({ offset: nextOffset })}
+            />
+          </>
         ) }
       </section>
     </main>
@@ -245,4 +254,21 @@ function TransactionsTable({ rows, sortBy, onChangeSort }: TransactionsTableProp
 
 function formatAmount(v: number) {
   return 'R' + v.toLocaleString('en-ZA', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+interface PaginationProps {
+  total: number; limit: number; offset: number; hasMore: boolean; onPageChange: (nextOffset: number) => void;
+}
+function Pagination({ total, limit, offset, hasMore, onPageChange }: PaginationProps) {
+  const from = offset + 1;
+  const to = Math.min(offset + limit, total);
+  const prevOffset = Math.max(0, offset - limit);
+  const nextOffset = offset + limit;
+  return (
+    <div className="tx-pager" aria-label="Pagination controls">
+      <button type="button" disabled={offset === 0} onClick={() => onPageChange(prevOffset)}>Previous</button>
+      <span className="tx-page-info">{from}–{to} of {total}</span>
+      <button type="button" disabled={!hasMore} onClick={() => onPageChange(nextOffset)}>Next</button>
+    </div>
+  );
 }

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,17 +1,4 @@
-import { AsyncSection } from '../components/Skeleton';
+import { TransactionsRoute } from '../app/routes/TransactionsRoute';
 
-// Skip artificial delay entirely in test environment to avoid flaky timeouts.
-const DELAY_MS = import.meta.env.MODE === 'test' ? 0 : 250; // Faster dev delay for snappy UX
-
-async function loadTransactions() {
-  if (DELAY_MS) await new Promise(r => setTimeout(r, DELAY_MS));
-  return (
-    <section aria-labelledby="transactions-heading">
-      <h2 id="transactions-heading">Transactions</h2>
-      <p>Transaction list and filters will appear here.</p>
-    </section>
-  );
-}
-
-export function Transactions() { return <AsyncSection load={loadTransactions} />; }
+export function Transactions() { return <TransactionsRoute />; }
 export default Transactions;

--- a/src/stories/Transactions.stories.tsx
+++ b/src/stories/Transactions.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TransactionsRoute } from '../app/routes/TransactionsRoute';
+import { DashboardProvider } from '../layouts/dashboard/DashboardProvider';
+import dashboardConfig from '../app/config/dashboard.config';
+import * as client from '../data/client';
+import type { FiltersResponse, TransactionsPage } from '../data/models';
+
+const meta: Meta = {
+  title: 'Transactions/Route',
+  component: TransactionsRoute,
+  parameters: { layout: 'fullscreen' }
+};
+export default meta;
+
+const mockFilters: FiltersResponse = {
+  categories: [
+    { name: 'Food', color: '#ff9900', icon: 'Utensils' },
+    { name: 'Travel', color: '#3366ff', icon: 'Plane' },
+  ],
+  dateRangePresets: [
+    { label: '7 Days', value: '7d' },
+    { label: '30 Days', value: '30d' },
+    { label: '90 Days', value: '90d' },
+    { label: '1 Year', value: '1y' }
+  ]
+};
+
+function makePage(empty = false): TransactionsPage {
+  return {
+    transactions: empty ? [] : Array.from({ length: 10 }).map((_, i) => ({
+      id: 't' + i,
+      date: new Date(2025, 8, 1 + i).toISOString(),
+      merchant: 'Merchant ' + i,
+      category: i % 2 ? 'Travel' : 'Food',
+      amount: i % 3 ? 100 + i : -50 - i,
+      description: 'Desc',
+      paymentMethod: 'Card',
+      icon: 'Circle',
+      categoryColor: '#000'
+    })),
+    pagination: { total: empty ? 0 : 100, limit: 20, offset: 0, hasMore: !empty }
+  };
+}
+
+function withData(empty = false) {
+  (client.filters as unknown as () => Promise<unknown>) = () => Promise.resolve(mockFilters);
+  (client.transactions as unknown as () => Promise<unknown>) = () => Promise.resolve(makePage(empty));
+  return (
+    <DashboardProvider config={dashboardConfig}>
+      <TransactionsRoute />
+    </DashboardProvider>
+  );
+}
+
+export const Default: StoryObj = { render: () => withData(false) };
+export const Empty: StoryObj = { render: () => withData(true) };
+export const DarkMode: StoryObj = {
+  parameters: { backgrounds: { default: 'dark' } },
+  render: () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    return withData(false);
+  }
+};

--- a/src/stories/Transactions.stories.tsx
+++ b/src/stories/Transactions.stories.tsx
@@ -61,3 +61,25 @@ export const DarkMode: StoryObj = {
     return withData(false);
   }
 };
+
+export const SortedAmountDesc: StoryObj = {
+  name: 'Sorted Amount Desc',
+  render: () => {
+    // force query param sortBy=amount_desc
+    window.history.replaceState({}, '', '?sortBy=amount_desc');
+    return withData(false);
+  }
+};
+
+export const ErrorState: StoryObj = {
+  name: 'Error State',
+  render: () => {
+    (client.filters as unknown as () => Promise<unknown>) = () => Promise.reject(new Error('Network down'));
+    (client.transactions as unknown as () => Promise<unknown>) = () => Promise.reject(new Error('Network down'));
+    return (
+      <DashboardProvider config={dashboardConfig}>
+        <TransactionsRoute />
+      </DashboardProvider>
+    );
+  }
+};

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -296,6 +296,27 @@ button {
   cursor: pointer;
   box-shadow: var(--shadow-sm);
 }
+
+/* Transactions Table Styling */
+.tx-table { width:100%; border-collapse:collapse; font-size: var(--fs-14); table-layout: fixed; }
+.tx-table thead th { position:sticky; top:0; background: var(--color-surface-alt); z-index:1; box-shadow: 0 1px 0 var(--color-border), 0 2px 4px rgba(0,0,0,0.06); }
+.tx-table thead th button.sortable { all:unset; cursor:pointer; display:inline-flex; align-items:center; gap:4px; padding: var(--sp-8) var(--sp-4); font-weight: var(--fw-medium); }
+.tx-table thead th button.sortable:focus-visible { outline: 2px solid var(--focus-ring-color); outline-offset:2px; border-radius:4px; }
+.tx-table tbody tr { transition: background-color .15s; }
+.tx-table tbody tr:nth-child(odd) { background: var(--color-surface); }
+.tx-table tbody tr:nth-child(even) { background: var(--color-surface-alt); }
+.tx-table tbody tr:hover { background: var(--color-accent-soft); }
+.tx-table td, .tx-table th { padding: 8px 12px; vertical-align: middle; }
+.tx-table td.neg { color: var(--brand-danger); font-weight: var(--fw-medium); }
+.tx-table td:nth-child(4) { text-align:right; font-variant-numeric: tabular-nums; }
+@media (prefers-color-scheme: dark) {
+  .tx-table tbody tr:nth-child(odd) { background: var(--color-surface-alt); }
+  .tx-table tbody tr:nth-child(even) { background: var(--color-surface); }
+  .tx-table tbody tr:hover { background: var(--color-accent-soft); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tx-table tbody tr { transition:none; }
+}
 /* Theme icon button specialized styles */
 .theme-icon-btn {
   background: var(--color-surface-alt);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -342,6 +342,15 @@ button {
 .tx-pager .pager-btn:hover:not(:disabled) { background: var(--brand-primary); color:#fff; }
 .tx-pager .pager-btn:disabled { opacity:.4; cursor:not-allowed; }
 .tx-pager .tx-page-info { font-size: var(--fs-12); color: var(--text-muted); }
+
+/* Empty & error refined */
+.tx-empty { display:flex; flex-direction:column; align-items:center; gap:8px; padding:32px 16px; text-align:center; background: var(--color-surface-alt); border:1px dashed var(--color-border); border-radius: var(--radius-12); }
+.tx-empty h3 { margin:0; font-size: var(--fs-16); }
+.tx-illustration { font-size:48px; line-height:1; }
+.tx-error { display:flex; align-items:center; gap:12px; background: var(--brand-danger); color:#fff; padding:12px 16px; border-radius: var(--radius-12); margin-bottom:16px; }
+.tx-error button { background:#fff; color: var(--brand-danger); border:none; padding:6px 12px; border-radius:8px; cursor:pointer; }
+.tx-error button:hover { background:#ffe5e3; }
+.tx-error .alert-icon { font-size:20px; }
 /* Theme icon button specialized styles */
 .theme-icon-btn {
   background: var(--color-surface-alt);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -351,6 +351,14 @@ button {
 .tx-error button { background:#fff; color: var(--brand-danger); border:none; padding:6px 12px; border-radius:8px; cursor:pointer; }
 .tx-error button:hover { background:#ffe5e3; }
 .tx-error .alert-icon { font-size:20px; }
+
+/* Utility: visually hidden (for additional live regions) */
+.visually-hidden { position:absolute !important; width:1px !important; height:1px !important; padding:0 !important; margin:-1px !important; overflow:hidden !important; clip:rect(0 0 0 0) !important; white-space:nowrap !important; border:0 !important; }
+
+/* Enhanced focus styling for interactive elements inside transactions */
+.transactions-route button:focus-visible,
+.transactions-route [role="tab"]:focus-visible,
+.transactions-route a:focus-visible { outline: 2px solid var(--focus-ring-color); outline-offset:2px; border-radius:6px; }
 /* Theme icon button specialized styles */
 .theme-icon-btn {
   background: var(--color-surface-alt);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -322,6 +322,14 @@ button {
 @media (prefers-reduced-motion: reduce) {
   .tx-table tbody tr { transition:none; }
 }
+
+/* Filter pills */
+.tx-active-pills { display:flex; flex-wrap:wrap; gap:8px; margin: 0 0 12px; align-items:center; }
+.tx-active-pills .pill { background: var(--color-surface-alt); border:1px solid var(--color-border); padding:4px 10px; border-radius: 999px; font-size: var(--fs-12); display:inline-flex; align-items:center; gap:6px; }
+.tx-active-pills .pill button { background: none; border:none; padding:0; margin:0; cursor:pointer; color: var(--color-text); font-size:14px; line-height:1; }
+.tx-active-pills .pill button:hover { color: var(--brand-danger); }
+.tx-active-pills .clear-all { background:none; border:none; color: var(--brand-primary); cursor:pointer; font-size: var(--fs-12); text-decoration:underline; }
+.tx-active-pills .clear-all:hover { color: var(--brand-danger); }
 /* Theme icon button specialized styles */
 .theme-icon-btn {
   background: var(--color-surface-alt);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -301,6 +301,11 @@ button {
 .tx-table { width:100%; border-collapse:collapse; font-size: var(--fs-14); table-layout: fixed; }
 .tx-table thead th { position:sticky; top:0; background: var(--color-surface-alt); z-index:1; box-shadow: 0 1px 0 var(--color-border), 0 2px 4px rgba(0,0,0,0.06); }
 .tx-table thead th button.sortable { all:unset; cursor:pointer; display:inline-flex; align-items:center; gap:4px; padding: var(--sp-8) var(--sp-4); font-weight: var(--fw-medium); }
+.tx-table thead th button.sortable .chevron { display:inline-block; transition: transform .18s var(--ease-standard), opacity .18s var(--ease-standard); opacity:.4; }
+.tx-table thead th button.sortable .chevron.ascending { transform: rotate(180deg); opacity:1; }
+.tx-table thead th button.sortable .chevron.descending { transform: rotate(0deg); opacity:1; }
+.tx-table thead th button.sortable .chevron.none { opacity:.15; }
+@media (prefers-reduced-motion: reduce) { .tx-table thead th button.sortable .chevron { transition:none; } }
 .tx-table thead th button.sortable:focus-visible { outline: 2px solid var(--focus-ring-color); outline-offset:2px; border-radius:4px; }
 .tx-table tbody tr { transition: background-color .15s; }
 .tx-table tbody tr:nth-child(odd) { background: var(--color-surface); }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -330,6 +330,13 @@ button {
 .tx-active-pills .pill button:hover { color: var(--brand-danger); }
 .tx-active-pills .clear-all { background:none; border:none; color: var(--brand-primary); cursor:pointer; font-size: var(--fs-12); text-decoration:underline; }
 .tx-active-pills .clear-all:hover { color: var(--brand-danger); }
+
+/* Pager pills */
+.tx-pager { display:flex; align-items:center; gap:12px; margin-top:16px; }
+.tx-pager .pager-btn { background: var(--color-surface-alt); color: var(--color-text); border:1px solid var(--color-border); padding:6px 14px; border-radius:999px; font-size: var(--fs-12); font-weight: var(--fw-medium); }
+.tx-pager .pager-btn:hover:not(:disabled) { background: var(--brand-primary); color:#fff; }
+.tx-pager .pager-btn:disabled { opacity:.4; cursor:not-allowed; }
+.tx-pager .tx-page-info { font-size: var(--fs-12); color: var(--text-muted); }
 /* Theme icon button specialized styles */
 .theme-icon-btn {
   background: var(--color-surface-alt);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -314,6 +314,11 @@ button {
 .tx-table td, .tx-table th { padding: 8px 12px; vertical-align: middle; }
 .tx-table td.neg { color: var(--brand-danger); font-weight: var(--fw-medium); }
 .tx-table td:nth-child(4) { text-align:right; font-variant-numeric: tabular-nums; }
+.tx-table td.merchant .merchant-name { font-weight: var(--fw-medium); }
+.tx-table td.category { display:flex; align-items:center; gap:6px; }
+.tx-table td.category .cat-dot { width:10px; height:10px; border-radius:50%; box-shadow: 0 0 0 1px rgba(0,0,0,0.15); }
+.tx-table td.method { display:flex; align-items:center; gap:6px; }
+.tx-table td.method .method-icon { font-size:14px; }
 @media (prefers-color-scheme: dark) {
   .tx-table tbody tr:nth-child(odd) { background: var(--color-surface-alt); }
   .tx-table tbody tr:nth-child(even) { background: var(--color-surface); }


### PR DESCRIPTION
This PR implements the Transactions route with responsive filters, a sortable, paginated table, and URL‑backed state. Users can filter by period (7d/30d/90d/1y) and category, sort by Date or Amount, and page through results. The UI is accessible, theme‑aware, and follows our skeleton + inline error patterns.
Details

URL state: category, period, limit, offset, sortBy (default date_desc).
Filters:

- Mobile: Bottom Sheet with Date presets + Category chips → Apply/Reset.
- Desktop: Persistent side panel (instant apply).


Table:

- Columns: Date, Merchant, Category, Amount, Payment Method.
- Sorting on Date/Amount with aria-sort and URL updates.
- ZAR formatting; negative amounts styled.


Pagination:

Prev/Next with page indicator; hasMore respected.


States:

- Skeleton loaders; Empty with Reset; Error with inline alert + Retry.


A11y & motion:

- Landmarks + aria-labelledby; chips with aria-pressed; headers with aria-sort.
- :focus-visible rings; prefers-reduced-motion respected.